### PR TITLE
fix: disable outputSchema validation by default to prevent -32602 errors

### DIFF
--- a/utils/registerToolWithMetadata.js
+++ b/utils/registerToolWithMetadata.js
@@ -123,8 +123,12 @@ export function registerToolWithMetadata(
     }
   };
 
-  // Add outputSchema if provided
-  if (processedOutputSchema) {
+  // Add outputSchema if provided and strict output validation is enabled.
+  // Disabled by default because several Freelo API responses don't match the
+  // declared schemas (e.g. project "state" is returned as an object, not a
+  // string), which causes MCP SDK output validation errors (-32602).
+  // Set FREELO_MCP_STRICT_OUTPUT=1 to re-enable schema validation.
+  if (processedOutputSchema && process.env.FREELO_MCP_STRICT_OUTPUT === '1') {
     config.outputSchema = processedOutputSchema;
   }
 


### PR DESCRIPTION
## Summary

- Freelo API responses don't match several declared `outputSchema` definitions (e.g. project `state` is returned as `{id, state}` object but schema declares `z.string()`)
- This causes MCP SDK output validation errors (`-32602`) on every tool call, making the server unusable with any MCP client
- Fix: skip `outputSchema` registration by default; opt back in with `FREELO_MCP_STRICT_OUTPUT=1` env var

## Reproduction

Any tool call that returns data (e.g. `get_all_projects`) fails with:
```
MCP error -32602: Output validation error: Invalid structured content for tool get_all_projects
```

## Root cause

The `outputSchema` definitions in `utils/schemas.js` don't match actual Freelo API v1 responses. Examples:
- `ProjectSchema.state` declared as `z.string()` but API returns `{id: 1, state: "active"}`
- Similar mismatches likely exist in other schemas

## Fix approach

Rather than fixing all 98+ schemas (which would require mapping every Freelo API response field), this PR disables `outputSchema` registration by default. The schemas and normalization logic remain intact — once schemas are corrected, strict validation can be re-enabled via `FREELO_MCP_STRICT_OUTPUT=1`.

## Test plan

- [x] Tested `get_all_projects` — returns 52 projects successfully
- [x] Verified `tools/list` returns 104 tools (all functional)
- [x] Confirmed `outputSchema` is omitted from tool registration (0/104)
- [x] Setting `FREELO_MCP_STRICT_OUTPUT=1` re-enables validation (old behavior)


🤖 Generated with [Claude Code](https://claude.com/claude-code)