### PR TITLE
fix: use correct 'note' field for work reports

### DIFF
--- a/tools/work-reports.js
+++ b/tools/work-reports.js
@@ -48,7 +48,7 @@ export function registerWorkReportsTools(server) {
       reportData: z.object({
         minutes: z.number().describe('Number of minutes worked (e.g., 120 for 2 hours, 30 for half hour). Will be converted to hours in reports.'),
         date: z.string().describe('Date of work in format YYYY-MM-DD (e.g., "2025-10-11"). Usually today\'s date or past date for retroactive entries.'),
-        description: z.string().optional().describe('Optional: Description of work performed (e.g., "Fixed login bug", "Client meeting notes"). Useful for detailed billing and reporting.')
+        note: z.string().optional().describe('Optional: Note about work performed (e.g., "Fixed login bug", "Client meeting notes"). Useful for detailed billing and reporting.')
       }).describe('Work report data')
     },
     withErrorHandling('create_work_report', async ({ taskId, reportData }) => {
@@ -71,7 +71,7 @@ export function registerWorkReportsTools(server) {
       reportData: z.object({
         minutes: z.number().optional().describe('Optional: Updated number of minutes worked (e.g., 120 for 2 hours)'),
         date: z.string().optional().describe('Optional: Updated date in format YYYY-MM-DD (e.g., "2025-10-11")'),
-        description: z.string().optional().describe('Optional: Updated description of work performed')
+        note: z.string().optional().describe('Optional: Updated note about work performed')
       }).describe('Updated work report data - all fields optional, only provide what needs to change')
     },
     withErrorHandling('update_work_report', async ({ workReportId, reportData }) => {

--- a/utils/schemas.js
+++ b/utils/schemas.js
@@ -230,7 +230,7 @@ export const WorkReportSchema = z.object({
   id: z.number().describe('Work report ID'),
   date_reported: z.string().describe('Date of work (YYYY-MM-DD)'),
   minutes: z.number().describe('Minutes worked'),
-  description: z.string().optional().nullable().describe('Work description'),
+  note: z.string().optional().nullable().describe('Work report note'),
   user: UserMinimalSchema.optional(),
   task: TaskMinimalSchema.optional(),
   project_id: z.number().optional().describe('Project ID'),


### PR DESCRIPTION
## Summary

- Work report `create_work_report` and `update_work_report` tools were sending `description` field to the Freelo API, but the API expects `note`
- This caused notes/descriptions to be silently ignored and never saved
- Renamed `description` → `note` in tool input schemas and output `WorkReportSchema`

## Files changed

- `tools/work-reports.js` — input schema field rename for create and update
- `utils/schemas.js` — `WorkReportSchema` output field rename

## Test plan

- [x] Create a work report with a `note` field and verify it's saved
- [x] Update an existing work report's `note` and verify the change persists
- [x] Get work reports and verify `note` field is returned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)