### PR TITLE
feat: add filePath support to upload_file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,6 @@ FREELO_USER_AGENT=freelo-mcp
 ## Known Issues
 
 - `get_all_tasks` with `projectId` filter returns tasks from all projects (Freelo API limitation)
-- `upload_file` may fail (API expects Blob, not Base64)
 - `create_subtask` returns incorrect `task_id` in response
 - `get_subtasks` returns subtasks from entire project instead of filtering by `taskId`
 

--- a/README.md
+++ b/README.md
@@ -549,9 +549,10 @@ docker run -p 3000:3000 freelo-mcp-sse
   - `type` - Typ (directory, link, file, document)
   - `p` - Pagination
 
-- `upload_file` - Upload souboru (✅ opraveno - FormData)
-  - Parametr `fileData` - Base64 encoded file
-  - Parametr `fileName` - Název souboru
+- `upload_file` - Upload souboru (max 100MB)
+  - Parametr `filePath` - Cesta k lokálnímu souboru (preferováno pro velké soubory)
+  - Parametr `fileData` - Base64 encoded file (pro malé soubory / data v paměti)
+  - Parametr `fileName` - Název souboru (povinný při fileData, volitelný při filePath)
 
 - `download_file` - Stažení souboru podle UUID
 
@@ -766,7 +767,12 @@ await stop_time_tracking()
 ### Soubory
 
 ```javascript
-// Upload souboru
+// Upload souboru z disku (preferováno pro velké soubory)
+await upload_file({
+  filePath: "/cesta/k/dokument.pdf"
+})
+
+// Upload souboru z base64 (pro malé soubory / data v paměti)
 const base64Data = Buffer.from("obsah souboru").toString('base64')
 await upload_file({
   fileName: "dokument.pdf",

--- a/tests/mcp-tools.test.js
+++ b/tests/mcp-tools.test.js
@@ -981,4 +981,108 @@ describe('MCP Tools', () => {
       expect(downloadData.contentType).toBe('text/plain');
     });
   });
+
+  // Test upload_file with filePath
+  describe('upload_file with filePath', () => {
+    it('should upload a file from disk using filePath', async () => {
+      const fs = await import('fs');
+      const os = await import('os');
+      const path = await import('path');
+      // Create a temporary file
+      const tmpDir = os.default.tmpdir();
+      const tmpFile = path.default.join(tmpDir, `freelo-test-${randomString(8)}.txt`);
+      const fileContent = `Test file content ${randomString(10)}`;
+      fs.default.writeFileSync(tmpFile, fileContent);
+
+      const mockFileUuid = 'filepath-upload-uuid-1234';
+      const mockUploadResponse = { uuid: mockFileUuid };
+
+      nock(TEST_ENV.FREELO_API_BASE_URL)
+        .post('/file/upload')
+        .reply(200, mockUploadResponse);
+
+      try {
+        const result = await tools.upload_file.handler({
+          filePath: tmpFile
+        });
+
+        expect(isValidResponse(result)).toBe(true);
+        const data = getResponseData(result);
+        expect(data).toHaveProperty('uuid', mockFileUuid);
+      } finally {
+        // Clean up temp file
+        fs.default.unlinkSync(tmpFile);
+      }
+    });
+
+    it('should use custom fileName when provided with filePath', async () => {
+      const fs = await import('fs');
+      const os = await import('os');
+      const path = await import('path');
+      const tmpDir = os.default.tmpdir();
+      const tmpFile = path.default.join(tmpDir, `freelo-test-${randomString(8)}.txt`);
+      fs.default.writeFileSync(tmpFile, 'test content');
+
+      const mockUploadResponse = { uuid: 'custom-name-uuid' };
+
+      nock(TEST_ENV.FREELO_API_BASE_URL)
+        .post('/file/upload')
+        .reply(200, mockUploadResponse);
+
+      try {
+        const result = await tools.upload_file.handler({
+          filePath: tmpFile,
+          fileName: 'custom-name.txt'
+        });
+
+        expect(isValidResponse(result)).toBe(true);
+        const data = getResponseData(result);
+        expect(data).toHaveProperty('uuid', 'custom-name-uuid');
+      } finally {
+        fs.default.unlinkSync(tmpFile);
+      }
+    });
+
+    it('should fail when file does not exist', async () => {
+      const result = await tools.upload_file.handler({
+        filePath: '/nonexistent/path/file.txt'
+      });
+
+      expect(result.isError).toBe(true);
+      const errorText = result.content[0].text;
+      expect(errorText).toContain('File not found');
+    });
+
+    it('should fail when neither filePath nor fileData is provided', async () => {
+      const result = await tools.upload_file.handler({
+        fileName: 'test.txt'
+      });
+
+      expect(result.isError).toBe(true);
+      const errorText = result.content[0].text;
+      expect(errorText).toContain('Either filePath or fileData must be provided');
+    });
+
+    it('should fail when both filePath and fileData are provided', async () => {
+      const result = await tools.upload_file.handler({
+        filePath: '/some/file.txt',
+        fileData: 'dGVzdA==',
+        fileName: 'test.txt'
+      });
+
+      expect(result.isError).toBe(true);
+      const errorText = result.content[0].text;
+      expect(errorText).toContain('Provide either filePath or fileData, not both');
+    });
+
+    it('should fail when fileData is provided without fileName', async () => {
+      const result = await tools.upload_file.handler({
+        fileData: 'dGVzdA=='
+      });
+
+      expect(result.isError).toBe(true);
+      const errorText = result.content[0].text;
+      expect(errorText).toContain('fileName is required when using fileData');
+    });
+  });
 });

--- a/tools/files.js
+++ b/tools/files.js
@@ -4,6 +4,8 @@
  */
 
 import { z } from 'zod';
+import fs from 'fs';
+import path from 'path';
 import FormData from 'form-data';
 import { getApiClient } from '../utils/authHelper.js';
 import { formatResponse } from '../utils/responseFormatter.js';
@@ -39,23 +41,58 @@ export function registerFilesTools(server) {
   registerToolWithMetadata(
     server,
     'upload_file',
-    'Uploads a file to Freelo. The file can then be attached to tasks, comments, or stored in project files. Supports any file type. Files are encoded as base64 for transfer. After upload, use the returned file UUID with download_file or to attach to tasks. Maximum file size depends on Freelo plan.',
+    'Uploads a file to Freelo (max 100MB). Supports two modes: (1) filePath — reads file directly from disk, best for large files and avoids base64 overhead; (2) fileData — accepts base64-encoded content, useful when file data is already in memory. Provide either filePath or fileData (not both). After upload, use the returned UUID to attach the file to tasks or comments via the files parameter.',
     {
-      fileData: z.string().describe('File content encoded as base64 string. Convert file bytes to base64 before passing. Example in Node.js: Buffer.from(fileBytes).toString("base64")'),
-      fileName: z.string().describe('Original filename with extension (e.g., "report.pdf", "screenshot.png", "document.docx"). Preserves file type and helps with identification.')
+      filePath: z.string().optional().describe('Absolute path to a local file to upload (e.g., "/Users/me/docs/report.pdf"). Preferred for large files — reads directly from disk with no base64 overhead. Mutually exclusive with fileData.'),
+      fileData: z.string().optional().describe('File content encoded as base64 string. Use for small files or when file data is already in memory. Mutually exclusive with filePath.'),
+      fileName: z.string().optional().describe('Filename with extension (e.g., "report.pdf"). Required when using fileData. Optional when using filePath — defaults to the original filename from the path.')
     },
-    withErrorHandling('upload_file', async ({ fileData, fileName }) => {
-      const apiClient = getApiClient();
+    withErrorHandling('upload_file', async ({ filePath, fileData, fileName }) => {
+      // Validate: exactly one of filePath or fileData must be provided
+      if (!filePath && !fileData) {
+        throw new Error('Either filePath or fileData must be provided.');
+      }
+      if (filePath && fileData) {
+        throw new Error('Provide either filePath or fileData, not both.');
+      }
 
+      const apiClient = getApiClient();
       const form = new FormData();
-      const fileBuffer = Buffer.from(fileData, 'base64');
-      form.append('file', fileBuffer, {
-        filename: fileName,
-        contentType: 'application/octet-stream'
-      });
+
+      if (filePath) {
+        // File path mode: read directly from disk (streaming, no base64 overhead)
+        const resolvedPath = path.resolve(filePath);
+        if (!fs.existsSync(resolvedPath)) {
+          throw new Error(`File not found: ${resolvedPath}`);
+        }
+        const stat = fs.statSync(resolvedPath);
+        if (stat.size > 100 * 1024 * 1024) {
+          throw new Error(`File exceeds 100MB limit: ${(stat.size / 1024 / 1024).toFixed(1)}MB`);
+        }
+        const resolvedFileName = fileName || path.basename(resolvedPath);
+        form.append('file', fs.createReadStream(resolvedPath), {
+          filename: resolvedFileName,
+          contentType: 'application/octet-stream'
+        });
+      } else {
+        // Base64 mode: decode and upload (backward compatible)
+        if (!fileName) {
+          throw new Error('fileName is required when using fileData.');
+        }
+        const fileBuffer = Buffer.from(fileData, 'base64');
+        if (fileBuffer.length > 100 * 1024 * 1024) {
+          throw new Error(`File exceeds 100MB limit: ${(fileBuffer.length / 1024 / 1024).toFixed(1)}MB`);
+        }
+        form.append('file', fileBuffer, {
+          filename: fileName,
+          contentType: 'application/octet-stream'
+        });
+      }
 
       const response = await apiClient.post('/file/upload', form, {
-        headers: form.getHeaders()
+        headers: form.getHeaders(),
+        maxContentLength: 105 * 1024 * 1024,
+        maxBodyLength: 105 * 1024 * 1024
       });
       return formatResponse(response.data);
     }),


### PR DESCRIPTION
## Summary

- **New `filePath` parameter** for `upload_file` — reads files directly from disk using streaming, avoiding base64 encoding overhead. Supports files up to 100MB (Freelo API limit).
- **Backward compatible** — existing `fileData` (base64) parameter still works as before.
- **Input validation** — mutually exclusive params, file existence check, 100MB size limit, required fileName for base64 mode.
- **Removed stale known issue** — "upload_file may fail (API expects Blob, not Base64)" was verified working via real API test.

### Usage

```javascript
// New: upload from disk (preferred for large files)
await upload_file({ filePath: "/path/to/report.pdf" })

// Existing: upload from base64 (still works)
await upload_file({ fileData: base64String, fileName: "report.pdf" })
```

## Test plan

- [x] 6 new unit tests added (filePath upload, custom fileName, file not found, missing params, both params, missing fileName)
- [x] All existing tests pass (34 passed, 2 skipped)
- [x] Real API test: uploaded file + attached to task comment successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)