### PR TITLE
fix(custom-fields): map enum payload fields to Freelo API contract (#13)

### DIFF
--- a/tests/mcp-tools-custom-fields.test.js
+++ b/tests/mcp-tools-custom-fields.test.js
@@ -315,8 +315,15 @@ describe('Custom Fields Tools', () => {
         custom_field_uuid: CUSTOM_FIELD_UUID,
         enum_option_uuid: ENUM_OPTION_UUID
       };
+      // The wire payload renames `enum_option_uuid` to `value` per the
+      // Freelo API contract (#13).
+      const wirePayload = {
+        task_id: TEST_DATA.taskId,
+        custom_field_uuid: CUSTOM_FIELD_UUID,
+        value: ENUM_OPTION_UUID
+      };
       const mockResponse = { success: true };
-      mockFreeloApi('POST', '/custom-field/add-or-edit-enum-value', 200, mockResponse, valueData);
+      mockFreeloApi('POST', '/custom-field/add-or-edit-enum-value', 200, mockResponse, wirePayload);
 
       const result = await tools.add_or_edit_enum_value.handler({ valueData });
 
@@ -331,10 +338,15 @@ describe('Custom Fields Tools', () => {
         custom_field_uuid: CUSTOM_FIELD_UUID,
         enum_option_uuid: 'invalid-uuid'
       };
+      const wirePayload = {
+        task_id: TEST_DATA.taskId,
+        custom_field_uuid: CUSTOM_FIELD_UUID,
+        value: 'invalid-uuid'
+      };
       mockFreeloApi('POST', '/custom-field/add-or-edit-enum-value', 400, {
         error: 'Bad Request',
         message: 'Invalid enum option'
-      }, valueData);
+      }, wirePayload);
 
       const result = await tools.add_or_edit_enum_value.handler({ valueData });
 
@@ -463,11 +475,14 @@ describe('Custom Fields Tools', () => {
         name: 'Critical',
         color: '#FF0000'
       };
+      // The wire payload renames `name` to `value` per the Freelo API
+      // contract (#13).
+      const wirePayload = { value: 'Critical', color: '#FF0000' };
       const mockResponse = {
         id: ENUM_OPTION_UUID,
         value: 'Critical'
       };
-      mockFreeloApi('POST', `/custom-field-enum/create/${CUSTOM_FIELD_UUID}`, 200, mockResponse, optionData);
+      mockFreeloApi('POST', `/custom-field-enum/create/${CUSTOM_FIELD_UUID}`, 200, mockResponse, wirePayload);
 
       const result = await tools.create_enum_option.handler({
         customFieldUuid: CUSTOM_FIELD_UUID,
@@ -484,11 +499,12 @@ describe('Custom Fields Tools', () => {
       const optionData = {
         name: 'Low Priority'
       };
+      const wirePayload = { value: 'Low Priority' };
       const mockResponse = {
         id: 'eo-uuid-new',
         value: 'Low Priority'
       };
-      mockFreeloApi('POST', `/custom-field-enum/create/${CUSTOM_FIELD_UUID}`, 200, mockResponse, optionData);
+      mockFreeloApi('POST', `/custom-field-enum/create/${CUSTOM_FIELD_UUID}`, 200, mockResponse, wirePayload);
 
       const result = await tools.create_enum_option.handler({
         customFieldUuid: CUSTOM_FIELD_UUID,
@@ -728,10 +744,11 @@ describe('Custom Fields Tools', () => {
 
       // 2. Create enum options
       const option1Data = { name: 'High', color: '#FF0000' };
+      const option1Wire = { value: 'High', color: '#FF0000' };
       mockFreeloApi('POST', `/custom-field-enum/create/${CUSTOM_FIELD_UUID}`, 200, {
         id: ENUM_OPTION_UUID,
         value: 'High'
-      }, option1Data);
+      }, option1Wire);
       const createOption1Result = await tools.create_enum_option.handler({
         customFieldUuid: CUSTOM_FIELD_UUID,
         optionData: option1Data
@@ -770,7 +787,12 @@ describe('Custom Fields Tools', () => {
         custom_field_uuid: CUSTOM_FIELD_UUID,
         enum_option_uuid: ENUM_OPTION_UUID
       };
-      mockFreeloApi('POST', '/custom-field/add-or-edit-enum-value', 200, { success: true }, enumValueData);
+      const enumValueWire = {
+        task_id: TEST_DATA.taskId,
+        custom_field_uuid: CUSTOM_FIELD_UUID,
+        value: ENUM_OPTION_UUID
+      };
+      mockFreeloApi('POST', '/custom-field/add-or-edit-enum-value', 200, { success: true }, enumValueWire);
       const assignResult = await tools.add_or_edit_enum_value.handler({ valueData: enumValueData });
       expect(isValidResponse(assignResult)).toBe(true);
       expect(getResponseData(assignResult)).toHaveProperty('success', true);

--- a/tools/custom-fields.js
+++ b/tools/custom-fields.js
@@ -134,7 +134,13 @@ export function registerCustomFieldsTools(server) {
     },
     withErrorHandling('add_or_edit_enum_value', async ({ valueData }) => {
       const apiClient = getApiClient();
-      const response = await apiClient.post('/custom-field/add-or-edit-enum-value', valueData);
+      // The Freelo API expects `value`, not `enum_option_uuid` — sending the
+      // wrong field name resulted in a 400 with "Expected a string. Got: NULL"
+      // (#13). Keep the schema's user-facing key intact for backwards
+      // compatibility but rename it on the wire.
+      const { enum_option_uuid, ...rest } = valueData;
+      const payload = { ...rest, value: enum_option_uuid };
+      const response = await apiClient.post('/custom-field/add-or-edit-enum-value', payload);
       return formatResponse(response.data);
     }),
     {
@@ -258,7 +264,14 @@ export function registerCustomFieldsTools(server) {
     },
     withErrorHandling('create_enum_option', async ({ customFieldUuid, optionData }) => {
       const apiClient = getApiClient();
-      const response = await apiClient.post(`/custom-field-enum/create/${customFieldUuid}`, optionData);
+      // Freelo expects `value`, not `name`, on this endpoint — sending
+      // `name` returned `Expected a string. Got: NULL` because the
+      // required `value` field was missing (#13). Translate before send.
+      const payload = { value: optionData.name };
+      if (optionData.color) {
+        payload.color = optionData.color;
+      }
+      const response = await apiClient.post(`/custom-field-enum/create/${customFieldUuid}`, payload);
       return formatResponse(response.data);
     }),
     {

--- a/tools/custom-fields.js
+++ b/tools/custom-fields.js
@@ -134,7 +134,7 @@ export function registerCustomFieldsTools(server) {
     },
     withErrorHandling('add_or_edit_enum_value', async ({ valueData }) => {
       const apiClient = getApiClient();
-      // The Freelo API expects `value`, not `enum_option_uuid` — sending the
+      // The Freelo API expects `value`, not `enum_option_uuid`, sending the
       // wrong field name resulted in a 400 with "Expected a string. Got: NULL"
       // (#13). Keep the schema's user-facing key intact for backwards
       // compatibility but rename it on the wire.
@@ -264,7 +264,7 @@ export function registerCustomFieldsTools(server) {
     },
     withErrorHandling('create_enum_option', async ({ customFieldUuid, optionData }) => {
       const apiClient = getApiClient();
-      // Freelo expects `value`, not `name`, on this endpoint — sending
+      // Freelo expects `value`, not `name`, on this endpoint, sending
       // `name` returned `Expected a string. Got: NULL` because the
       // required `value` field was missing (#13). Translate before send.
       const payload = { value: optionData.name };


### PR DESCRIPTION
Fixes #13. Two enum-handling tools sent the wrong field names on the wire and produced `400 Bad Request` from Freelo:

1. **`create_enum_option`** sent `{ name: ... }`. The Freelo `POST /custom-field-enum/create/{uuid}` endpoint expects `{ value: ... }` and returned `Expected a string. Got: NULL` because the required `value` field was missing.
2. **`add_or_edit_enum_value`** sent `{ ..., enum_option_uuid: ... }`. The Freelo `POST /custom-field/add-or-edit-enum-value` endpoint expects `{ ..., value: ... }` (where `value` is the option UUID).

## Change

`tools/custom-fields.js`:

- `create_enum_option` builds a wire payload `{ value: optionData.name, [color: optionData.color] }` before posting. The user-facing tool schema keeps `name` so existing callers don't break.
- `add_or_edit_enum_value` destructures `enum_option_uuid` out of `valueData` and re-emits it as `value` in the wire payload. Tool schema unchanged.

## Test plan

- [x] `pnpm test tests/mcp-tools-custom-fields.test.js`, 32/32 pass
- [x] Updated existing nock mocks to expect the new wire shape (3 mocks for the simple cases + 2 mocks in the workflow test); pre-fix the matching failures reproduced the issue
- [x] User-facing schema unchanged, `optionData.name` and `valueData.enum_option_uuid` still accepted from clients