### PR TITLE
fix(schemas): ProjectSchema.state matches API object shape (#5)

### DIFF
--- a/utils/schemas.js
+++ b/utils/schemas.js
@@ -132,7 +132,10 @@ export const ProjectSchema = z.object({
   tasklists: z.array(TasklistMinimalSchema).optional().describe('Active tasklists'),
   client: ClientSchema.optional().nullable().describe('Client information'),
   owner: UserMinimalSchema.optional().nullable().describe('Project owner'),
-  state: z.string().optional().describe('Project state'),
+  state: z.object({
+    id: z.number(),
+    state: z.string()
+  }).optional().describe('Project state object'),
   currency_iso: z.enum(['CZK', 'EUR', 'USD']).optional().describe('Project currency')
 }).describe('Project object');
 


### PR DESCRIPTION
Fixes #5.

`ProjectSchema.state` was declared as `z.string()`, but Freelo's API returns it as an object `{ id, state }`. This caused MCP SDK output validation errors (`-32602`) when calling `get_all_projects` and related tools — and was the underlying reason PR #4 had to temporarily disable output schema validation.

## Change

`utils/schemas.js` — `state` is now `z.object({ id: z.number(), state: z.string() }).optional()`.

## Test plan

- [x] `npm test -- tests/schemas.test.js` — passes (2/2)
- [x] Overall suite: failed-test count drops from 3 → 1 (the remaining failure is unrelated, in untracked WIP test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)